### PR TITLE
Add sortable columns to grid

### DIFF
--- a/.changeset/nice-poets-hope.md
+++ b/.changeset/nice-poets-hope.md
@@ -1,0 +1,5 @@
+---
+'@sanomalearning/slds-grid': patch
+---
+
+Add sortable columns

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,9 +26,10 @@
     "./radio-group/register.js": "./dist/components/radio-group/register.js",
     "./tooltip": "./dist/components/tooltip/index.js",
     "./tooltip/register.js": "./dist/components/tooltip/register.js",
+    "./utils": "./dist/components/utils/index.js",
     "./utils/controllers": "./dist/components/utils/controllers/index.js",
-    "./utils/decorators": "./dist/components/utils/decorators/index.js",
-    "./utils/string.js": "./dist/components/utils/string.js"
+    "./utils/data-source": "./dist/components/utils/data-source/index.js",
+    "./utils/decorators": "./dist/components/utils/decorators/index.js"
   },
   "scripts": {
     "build": "wireit",

--- a/packages/core/src/dialog/dialog.scss
+++ b/packages/core/src/dialog/dialog.scss
@@ -31,6 +31,8 @@ dialog {
   transition: opacity 0.5s cubic-bezier(0.25, 0, 0.3, 1);
 
   &::backdrop {
+    /* stylelint-disable-next-line property-no-vendor-prefix */
+    -webkit-backdrop-filter: blur(3px);
     backdrop-filter: blur(3px);
     transition: backdrop-filter 0.5s ease;
   }

--- a/packages/core/src/utils/controllers/selection.ts
+++ b/packages/core/src/utils/controllers/selection.ts
@@ -17,7 +17,7 @@ export class SelectionController<T> {
   #selection = new Set<T>();
 
   /** The total number of items in the selection. */
-  count = 0;
+  size = 0;
 
   /** Whether more than 1 item can be selected at a time. */
   multiple = false;
@@ -71,7 +71,7 @@ export class SelectionController<T> {
     if (this.#selectAll) {
       return this.#selection.size === 0;
     } else {
-      return this.#selection.size === this.count;
+      return this.#selection.size === this.size;
     }
   }
 
@@ -79,9 +79,9 @@ export class SelectionController<T> {
     const { size } = this.#selection;
 
     if (this.#selectAll) {
-      return size > 0 && size !== this.count;
+      return size > 0 && size !== this.size;
     } else {
-      return size > 0 && size < this.count;
+      return size > 0 && size < this.size;
     }
   }
 

--- a/packages/core/src/utils/data-source/array-data-source.ts
+++ b/packages/core/src/utils/data-source/array-data-source.ts
@@ -1,0 +1,81 @@
+import type { DataSourceFilterFunction, DataSourceSortFunction } from './data-source.js';
+import { getStringByPath, getValueByPath } from '../path.js';
+import { DataSource } from './data-source.js';
+
+export class ArrayDataSource<T> extends DataSource<T> {
+  /** Array of filtered & sorted items. */
+  #items: T[] = [];
+
+  /** The original array of items as passed to the constructor. */
+  #originalItems: T[];
+
+  get items(): T[] {
+    return this.#items;
+  }
+
+  get size(): number {
+    return this.#items.length;
+  }
+
+  constructor(items: T[]) {
+    super();
+    this.#items = [...items];
+    this.#originalItems = [...items];
+  }
+
+  update(): void {
+    let items = [...this.#originalItems];
+
+    if (this.filterValue) {
+      const filterFn: DataSourceFilterFunction<T> =
+        this.filter?.(this.filterValue, this.filterLabelPath) || this.#filter(this.filterValue, this.filterLabelPath);
+
+      items = items.filter(filterFn);
+    }
+
+    if (this.sortValue) {
+      let sortFn: DataSourceSortFunction<T> | undefined = this.sorter?.(this.sortValue);
+
+      if (!sortFn) {
+        const { path, direction } = this.sortValue,
+          ascending = direction === 'asc';
+
+        sortFn = (a, b) => {
+          const valueA = getStringByPath(a, path),
+            valueB = getStringByPath(b, path);
+
+          if (valueA === valueB) {
+            return 0;
+          } else if (valueA < valueB) {
+            return ascending ? -1 : 1;
+          } else {
+            return ascending ? 1 : -1;
+          }
+        };
+      }
+
+      items.sort(sortFn);
+    }
+
+    this.#items = items;
+    this.dispatchEvent(new CustomEvent<void>('update'));
+  }
+
+  #filter(value: string, labelPath?: string): DataSourceFilterFunction<T> {
+    const regex = new RegExp(value, 'i');
+
+    if (!labelPath) {
+      return item => {
+        if (typeof item === 'string') {
+          return regex.test(item);
+        } else {
+          // We can't filter an object we don't know
+          return true;
+        }
+      };
+    }
+
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    return item => regex.test(`${getValueByPath(item, labelPath)}`);
+  }
+}

--- a/packages/core/src/utils/data-source/data-source.ts
+++ b/packages/core/src/utils/data-source/data-source.ts
@@ -1,0 +1,37 @@
+export type DataSourceFilter<T> = (value: unknown, labelPath?: string) => DataSourceFilterFunction<T>;
+
+export type DataSourceFilterFunction<T> = (item: T, index: number, array: T[]) => boolean;
+
+export type DataSourceSortDirection = 'asc' | 'desc';
+
+export type DataSourceSortValue = { path: string; direction: DataSourceSortDirection };
+
+export type DataSourceSortFunction<T> = (a: T, b: T) => number;
+
+export type DataSourceSorter<T> = (sort: DataSourceSortValue) => DataSourceSortFunction<T>;
+
+export abstract class DataSource<T> extends EventTarget {
+  /** The filter implementation. */
+  filter?: DataSourceFilter<T>;
+
+  /** The path to the label for use when filtering. */
+  filterLabelPath?: string;
+
+  /** The value to filter on. */
+  filterValue?: string;
+
+  /** The sorter implementation. */
+  sorter?: DataSourceSorter<T>;
+
+  /** The path & direction to sort on. */
+  sortValue?: DataSourceSortValue;
+
+  /** The array of items. */
+  abstract readonly items: T[];
+
+  /** Size of the item collection. */
+  abstract readonly size: number;
+
+  /** Updates the list of items using filter and sorting if available. */
+  abstract update(): void;
+}

--- a/packages/core/src/utils/data-source/index.ts
+++ b/packages/core/src/utils/data-source/index.ts
@@ -1,0 +1,2 @@
+export * from './array-data-source.js';
+export * from './data-source.js';

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './css.js';
+export * from './path.js';
+export * from './string.js';

--- a/packages/core/src/utils/path.ts
+++ b/packages/core/src/utils/path.ts
@@ -1,4 +1,4 @@
-import { humanize } from '@sanomalearning/slds-core/utils/string.js';
+import { humanize } from './string.js';
 
 export const getNameByPath = (path?: string): string => {
   if (!path) {
@@ -7,6 +7,17 @@ export const getNameByPath = (path?: string): string => {
     const parts = path.split('.');
 
     return humanize(parts[parts.length - 1]);
+  }
+};
+
+export const getStringByPath = (object: unknown, path = ''): string => {
+  const value = getValueByPath(object, path);
+
+  if (value) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    return value.toString();
+  } else {
+    return '';
   }
 };
 

--- a/packages/grid/src/column.ts
+++ b/packages/grid/src/column.ts
@@ -1,8 +1,8 @@
 import type { TemplateResult } from 'lit';
 import type { Grid } from './grid.js';
+import { getNameByPath, getValueByPath } from '@sanomalearning/slds-core/utils';
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
-import { getNameByPath, getValueByPath } from './utils.js';
 
 export type GridColumnRenderer<T> = (model: T) => TemplateResult;
 

--- a/packages/grid/src/grid.stories.ts
+++ b/packages/grid/src/grid.stories.ts
@@ -65,6 +65,19 @@ export const SelectionColumn: StoryObj = {
   }
 };
 
+export const SortableColumns: StoryObj = {
+  loaders: [async () => ({ people: (await getPeople()).people })],
+  render: (_, { loaded: { people } }) => {
+    return html`
+      <sl-grid .items=${people}>
+        <sl-grid-sort-column path="firstName"></sl-grid-sort-column>
+        <sl-grid-sort-column path="lastName"></sl-grid-sort-column>
+        <sl-grid-sort-column path="email"></sl-grid-sort-column>
+      </sl-grid>
+    `;
+  }
+};
+
 export const StickyColumns: StoryObj = {
   loaders: [async () => ({ people: (await getPeople()).people })],
   render: (_, { loaded: { people } }) => {

--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -1,2 +1,4 @@
 export * from './column.js';
 export * from './grid.js';
+export * from './selection-column.js';
+export * from './sort-column.js';

--- a/packages/grid/src/register.ts
+++ b/packages/grid/src/register.ts
@@ -1,15 +1,21 @@
 import { Grid } from './grid.js';
 import { GridColumn } from './column.js';
 import { GridSelectionColumn } from './selection-column.js';
+import { GridSortColumn } from './sort-column.js';
+import { GridSorter } from './sorter.js';
 
 customElements.define('sl-grid', Grid);
 customElements.define('sl-grid-column', GridColumn);
 customElements.define('sl-grid-selection-column', GridSelectionColumn);
+customElements.define('sl-grid-sort-column', GridSortColumn);
+customElements.define('sl-grid-sorter', GridSorter);
 
 declare global {
   interface HTMLElementTagNameMap {
     'sl-grid': Grid;
     'sl-grid-column': GridColumn;
     'sl-grid-selection-column': GridSelectionColumn;
+    'sl-grid-sort-column': GridSortColumn;
+    'sl-grid-sorter': GridSorter;
   }
 }

--- a/packages/grid/src/sort-column.ts
+++ b/packages/grid/src/sort-column.ts
@@ -1,0 +1,24 @@
+import type { TemplateResult } from 'lit';
+import type { ScopedElementsMap } from '@open-wc/scoped-elements';
+import { ScopedElementsMixin } from '@open-wc/scoped-elements';
+import { html } from 'lit';
+import { GridColumn } from './column.js';
+import { getNameByPath } from './utils.js';
+import { GridSorter } from './sorter.js';
+
+export class GridSortColumn extends ScopedElementsMixin(GridColumn) {
+  /** @private */
+  static get scopedElements(): ScopedElementsMap {
+    return {
+      'sl-grid-sorter': GridSorter
+    };
+  }
+
+  override renderHeader(): TemplateResult {
+    return html`
+      <th>
+        <sl-grid-sorter .path=${this.path}>${this.header ?? getNameByPath(this.path)}</sl-grid-sorter>
+      </th>
+    `;
+  }
+}

--- a/packages/grid/src/sort-column.ts
+++ b/packages/grid/src/sort-column.ts
@@ -1,9 +1,9 @@
 import type { TemplateResult } from 'lit';
 import type { ScopedElementsMap } from '@open-wc/scoped-elements';
 import { ScopedElementsMixin } from '@open-wc/scoped-elements';
+import { getNameByPath } from '@sanomalearning/slds-core/utils';
 import { html } from 'lit';
 import { GridColumn } from './column.js';
-import { getNameByPath } from './utils.js';
 import { GridSorter } from './sorter.js';
 
 export class GridSortColumn extends ScopedElementsMixin(GridColumn) {

--- a/packages/grid/src/sorter.scss
+++ b/packages/grid/src/sorter.scss
@@ -1,0 +1,9 @@
+:host {
+  --_gap: 0.5rem;
+}
+
+:host {
+  cursor: pointer;
+  display: inline-flex;
+  gap: var(--_gap);
+}

--- a/packages/grid/src/sorter.ts
+++ b/packages/grid/src/sorter.ts
@@ -1,11 +1,15 @@
 import type { TemplateResult } from 'lit';
+import type { EventEmitter } from '@sanomalearning/slds-core/utils/decorators';
 import { EventsController } from '@sanomalearning/slds-core/utils/controllers';
+import { event } from '@sanomalearning/slds-core/utils/decorators';
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { choose } from 'lit/directives/choose.js';
 import styles from './sorter.scss.js';
 
 export type GridSorterDirection = 'asc' | 'desc' | undefined;
+
+export type GridSorterChange = 'added' | 'removed';
 
 export class GridSorter extends LitElement {
   /** @private */
@@ -16,10 +20,22 @@ export class GridSorter extends LitElement {
   /** The direction in which to sort the items. */
   @property({ reflect: true }) direction?: GridSorterDirection;
 
+  @event() directionChange!: EventEmitter<GridSorterDirection>;
+
+  @event() sorterChange!: EventEmitter<GridSorterChange>;
+
   override connectedCallback(): void {
     super.connectedCallback();
 
     this.#events.listen(this, 'click', this.#onClick);
+
+    this.sorterChange.emit('added');
+  }
+
+  override disconnectedCallback(): void {
+    this.sorterChange.emit('removed');
+
+    super.disconnectedCallback();
   }
 
   override render(): TemplateResult {
@@ -36,6 +52,10 @@ export class GridSorter extends LitElement {
     `;
   }
 
+  reset(): void {
+    this.direction = undefined;
+  }
+
   #onClick(): void {
     if (this.direction === 'asc') {
       this.direction = 'desc';
@@ -44,5 +64,7 @@ export class GridSorter extends LitElement {
     } else {
       this.direction = 'asc';
     }
+
+    this.directionChange.emit(this.direction);
   }
 }

--- a/packages/grid/src/sorter.ts
+++ b/packages/grid/src/sorter.ts
@@ -1,0 +1,48 @@
+import type { TemplateResult } from 'lit';
+import { EventsController } from '@sanomalearning/slds-core/utils/controllers';
+import { LitElement, html } from 'lit';
+import { property } from 'lit/decorators.js';
+import { choose } from 'lit/directives/choose.js';
+import styles from './sorter.scss.js';
+
+export type GridSorterDirection = 'asc' | 'desc' | undefined;
+
+export class GridSorter extends LitElement {
+  /** @private */
+  static override styles = styles;
+
+  #events = new EventsController(this);
+
+  /** The direction in which to sort the items. */
+  @property({ reflect: true }) direction?: GridSorterDirection;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    this.#events.listen(this, 'click', this.#onClick);
+  }
+
+  override render(): TemplateResult {
+    return html`
+      <slot></slot>
+      ${choose(
+        this.direction,
+        [
+          ['asc', () => html`⬆️`],
+          ['desc', () => html`⬇️`]
+        ],
+        () => html`↕️`
+      )}
+    `;
+  }
+
+  #onClick(): void {
+    if (this.direction === 'asc') {
+      this.direction = 'desc';
+    } else if (this.direction === 'desc') {
+      this.direction = undefined;
+    } else {
+      this.direction = 'asc';
+    }
+  }
+}

--- a/packages/grid/src/sorter.ts
+++ b/packages/grid/src/sorter.ts
@@ -28,7 +28,10 @@ export class GridSorter extends LitElement {
   override connectedCallback(): void {
     super.connectedCallback();
 
+    this.tabIndex = 0;
+
     this.#events.listen(this, 'click', this.#onClick);
+    this.#events.listen(this, 'keydown', this.#onKeydown);
 
     this.sorterChange.emit('added');
   }
@@ -74,6 +77,20 @@ export class GridSorter extends LitElement {
   }
 
   #onClick(): void {
+    this.#toggleDirection();
+    this.directionChange.emit(this.direction);
+  }
+
+  #onKeydown(event: KeyboardEvent): void {
+    if ([' ', 'Enter'].includes(event.key)) {
+      event.preventDefault();
+
+      this.#toggleDirection();
+      this.directionChange.emit(this.direction);
+    }
+  }
+
+  #toggleDirection(): void {
     if (this.direction === 'asc') {
       this.direction = 'desc';
     } else if (this.direction === 'desc') {
@@ -81,7 +98,5 @@ export class GridSorter extends LitElement {
     } else {
       this.direction = 'asc';
     }
-
-    this.directionChange.emit(this.direction);
   }
 }

--- a/packages/grid/src/sorter.ts
+++ b/packages/grid/src/sorter.ts
@@ -1,4 +1,4 @@
-import type { TemplateResult } from 'lit';
+import type { PropertyValues, TemplateResult } from 'lit';
 import type { DataSourceSortDirection } from '@sanomalearning/slds-core/utils/data-source';
 import type { EventEmitter } from '@sanomalearning/slds-core/utils/decorators';
 import { EventsController } from '@sanomalearning/slds-core/utils/controllers';
@@ -33,6 +33,20 @@ export class GridSorter extends LitElement {
     this.sorterChange.emit('added');
   }
 
+  override updated(changes: PropertyValues<this>): void {
+    super.updated(changes);
+
+    if (changes.has('direction')) {
+      const header = this.closest('th');
+
+      if (!this.direction) {
+        header?.removeAttribute('aria-sort');
+      } else {
+        header?.setAttribute('aria-sort', this.direction === 'asc' ? 'ascending' : 'descending');
+      }
+    }
+  }
+
   override disconnectedCallback(): void {
     this.sorterChange.emit('removed');
 
@@ -42,14 +56,16 @@ export class GridSorter extends LitElement {
   override render(): TemplateResult {
     return html`
       <slot></slot>
-      ${choose(
-        this.direction,
-        [
-          ['asc', () => html`⬆️`],
-          ['desc', () => html`⬇️`]
-        ],
-        () => html`↕️`
-      )}
+      <span aria-hidden="true" class="direction">
+        ${choose(
+          this.direction,
+          [
+            ['asc', () => html`⬆️`],
+            ['desc', () => html`⬇️`]
+          ],
+          () => html`↕️`
+        )}
+      </span>
     `;
   }
 

--- a/packages/grid/src/sorter.ts
+++ b/packages/grid/src/sorter.ts
@@ -1,4 +1,5 @@
 import type { TemplateResult } from 'lit';
+import type { DataSourceSortDirection } from '@sanomalearning/slds-core/utils/data-source';
 import type { EventEmitter } from '@sanomalearning/slds-core/utils/decorators';
 import { EventsController } from '@sanomalearning/slds-core/utils/controllers';
 import { event } from '@sanomalearning/slds-core/utils/decorators';
@@ -6,8 +7,6 @@ import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { choose } from 'lit/directives/choose.js';
 import styles from './sorter.scss.js';
-
-export type GridSorterDirection = 'asc' | 'desc' | undefined;
 
 export type GridSorterChange = 'added' | 'removed';
 
@@ -18,9 +17,11 @@ export class GridSorter extends LitElement {
   #events = new EventsController(this);
 
   /** The direction in which to sort the items. */
-  @property({ reflect: true }) direction?: GridSorterDirection;
+  @property({ reflect: true }) direction?: DataSourceSortDirection;
 
-  @event() directionChange!: EventEmitter<GridSorterDirection>;
+  @event() directionChange!: EventEmitter<DataSourceSortDirection | undefined>;
+
+  @property() path?: string;
 
   @event() sorterChange!: EventEmitter<GridSorterChange>;
 


### PR DESCRIPTION
- Add `@sanomalearning/utils/data-source` with `ArrayDataSource`
- Add `dataSource` property to `Grid` and use that for filtering & sorting
- Add `<sl-grid-sort-column>` for sortable columns
- Fix dialog backdrop blur in Safari