### PR TITLE
Add label component

### DIFF
--- a/.changeset/thirty-meals-sell.md
+++ b/.changeset/thirty-meals-sell.md
@@ -1,0 +1,5 @@
+---
+'@sanomalearning/slds-core': patch
+---
+
+Add label component

--- a/packages/core/.storybook/main.js
+++ b/packages/core/.storybook/main.js
@@ -8,6 +8,7 @@ export default {
     {
       name: '@storybook/addon-essentials',
       options: {
+        actions: false,
         backgrounds: false
       }
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,8 @@
     "./dialog/register.js": "./dist/components/dialog/register.js",
     "./input": "./dist/components/input/index.js",
     "./input/register.js": "./dist/components/input/register.js",
+    "./label": "./dist/components/label/index.js",
+    "./label/register.js": "./dist/components/label/register.js",
     "./popover": "./dist/components/popover/index.js",
     "./popover/register.js": "./dist/components/popover/register.js",
     "./radio-group": "./dist/components/radio-group/index.js",

--- a/packages/core/src/label/index.ts
+++ b/packages/core/src/label/index.ts
@@ -1,0 +1,1 @@
+export * from './label.js';

--- a/packages/core/src/label/label.scss
+++ b/packages/core/src/label/label.scss
@@ -1,0 +1,3 @@
+:host {
+  font-weight: bold;
+}

--- a/packages/core/src/label/label.scss
+++ b/packages/core/src/label/label.scss
@@ -1,3 +1,7 @@
 :host {
-  font-weight: bold;
+  --_font-weight: 600;
+}
+
+:host {
+  font-weight: var(--_font-weight);
 }

--- a/packages/core/src/label/label.scss
+++ b/packages/core/src/label/label.scss
@@ -6,6 +6,7 @@
   font-weight: var(--_font-weight);
 }
 
+.optional,
 .required {
   margin-left: 0.25rem;
 }

--- a/packages/core/src/label/label.scss
+++ b/packages/core/src/label/label.scss
@@ -5,3 +5,7 @@
 :host {
   font-weight: var(--_font-weight);
 }
+
+.required {
+  margin-left: 0.25rem;
+}

--- a/packages/core/src/label/label.stories.ts
+++ b/packages/core/src/label/label.stories.ts
@@ -1,0 +1,28 @@
+import type { StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import '../input/register.js';
+import './register.js';
+
+export default {
+  title: 'Label'
+};
+
+export const API: StoryObj = {
+  args: {
+    required: false,
+    text: 'Label text'
+  },
+  render: ({ required, text }) => html`
+    <style>
+      div {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+    </style>
+    <div>
+      <sl-label for="input">${text}</sl-label>
+      <sl-input ?required=${required} id="input"></sl-input>
+    </div>
+  `
+};

--- a/packages/core/src/label/label.stories.ts
+++ b/packages/core/src/label/label.stories.ts
@@ -26,3 +26,111 @@ export const API: StoryObj = {
     </div>
   `
 };
+
+export const CustomLabel: StoryObj = {
+  render: () => html`
+    <style>
+      div {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+    </style>
+    <div>
+      <sl-label for="input">
+        <label slot="label"><u>Hello</u> <em>World</em></label>
+      </sl-label>
+      <sl-input id="input"></sl-input>
+    </div>
+  `
+};
+
+export const Required: StoryObj = {
+  render: () => html`
+    <style>
+      form {
+        display: grid;
+        grid-template-rows: repeat(3, [label] auto 0.25rem [control] auto 0.5rem);
+      }
+
+      sl-label {
+        grid-row: label 1;
+      }
+
+      sl-input {
+        grid-row: control 1;
+      }
+
+      sl-label:nth-of-type(2) {
+        grid-row: label 2;
+      }
+
+      sl-input:nth-of-type(2) {
+        grid-row: control 2;
+      }
+
+      sl-label:nth-of-type(3) {
+        grid-row: label 3;
+      }
+
+      sl-input:nth-of-type(3) {
+        grid-row: control 3;
+      }
+    </style>
+    <form>
+      <sl-label for="input">This label should be marked as required</sl-label>
+      <sl-input required id="input"></sl-input>
+
+      <sl-label for="input2">Input 2</sl-label>
+      <sl-input id="input2"></sl-input>
+
+      <sl-label for="input3">Input 3</sl-label>
+      <sl-input id="input3"></sl-input>
+    </form>
+  `
+};
+
+export const Optional: StoryObj = {
+  render: () => html`
+    <style>
+      form {
+        display: grid;
+        grid-template-rows: repeat(3, [label] auto 0.25rem [control] auto 0.5rem);
+      }
+
+      sl-label {
+        grid-row: label 1;
+      }
+
+      sl-input {
+        grid-row: control 1;
+      }
+
+      sl-label:nth-of-type(2) {
+        grid-row: label 2;
+      }
+
+      sl-input:nth-of-type(2) {
+        grid-row: control 2;
+      }
+
+      sl-label:nth-of-type(3) {
+        grid-row: label 3;
+      }
+
+      sl-input:nth-of-type(3) {
+        grid-row: control 3;
+      }
+    </style>
+    <form>
+      <sl-label for="input">This label should be marked as optional</sl-label>
+      <sl-input id="input"></sl-input>
+
+      <sl-label for="input2">Input 2</sl-label>
+      <sl-input required id="input2"></sl-input>
+
+      <sl-label for="input3">Input 3</sl-label>
+      <sl-input required id="input3"></sl-input>
+    </form>
+  `
+};

--- a/packages/core/src/label/label.stories.ts
+++ b/packages/core/src/label/label.stories.ts
@@ -49,32 +49,13 @@ export const Required: StoryObj = {
   render: () => html`
     <style>
       form {
-        display: grid;
-        grid-template-rows: repeat(3, [label] auto 0.25rem [control] auto 0.5rem);
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
       }
 
-      sl-label {
-        grid-row: label 1;
-      }
-
-      sl-input {
-        grid-row: control 1;
-      }
-
-      sl-label:nth-of-type(2) {
-        grid-row: label 2;
-      }
-
-      sl-input:nth-of-type(2) {
-        grid-row: control 2;
-      }
-
-      sl-label:nth-of-type(3) {
-        grid-row: label 3;
-      }
-
-      sl-input:nth-of-type(3) {
-        grid-row: control 3;
+      sl-input:not(:last-of-type) {
+        margin-block-end: 0.5rem;
       }
     </style>
     <form>
@@ -94,32 +75,13 @@ export const Optional: StoryObj = {
   render: () => html`
     <style>
       form {
-        display: grid;
-        grid-template-rows: repeat(3, [label] auto 0.25rem [control] auto 0.5rem);
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
       }
 
-      sl-label {
-        grid-row: label 1;
-      }
-
-      sl-input {
-        grid-row: control 1;
-      }
-
-      sl-label:nth-of-type(2) {
-        grid-row: label 2;
-      }
-
-      sl-input:nth-of-type(2) {
-        grid-row: control 2;
-      }
-
-      sl-label:nth-of-type(3) {
-        grid-row: label 3;
-      }
-
-      sl-input:nth-of-type(3) {
-        grid-row: control 3;
+      sl-input:not(:last-of-type) {
+        margin-block-end: 0.5rem;
       }
     </style>
     <form>

--- a/packages/core/src/label/label.stories.ts
+++ b/packages/core/src/label/label.stories.ts
@@ -81,10 +81,10 @@ export const Required: StoryObj = {
       <sl-label for="input">This label should be marked as required</sl-label>
       <sl-input required id="input"></sl-input>
 
-      <sl-label for="input2">Input 2</sl-label>
+      <sl-label for="input2">Optional input</sl-label>
       <sl-input id="input2"></sl-input>
 
-      <sl-label for="input3">Input 3</sl-label>
+      <sl-label for="input3">Optional input</sl-label>
       <sl-input id="input3"></sl-input>
     </form>
   `
@@ -126,10 +126,10 @@ export const Optional: StoryObj = {
       <sl-label for="input">This label should be marked as optional</sl-label>
       <sl-input id="input"></sl-input>
 
-      <sl-label for="input2">Input 2</sl-label>
+      <sl-label for="input2">Required input</sl-label>
       <sl-input required id="input2"></sl-input>
 
-      <sl-label for="input3">Input 3</sl-label>
+      <sl-label for="input3">Required input</sl-label>
       <sl-input required id="input3"></sl-input>
     </form>
   `

--- a/packages/core/src/label/label.ts
+++ b/packages/core/src/label/label.ts
@@ -75,11 +75,16 @@ export class Label extends LitElement {
   #onSlotchange({ target }: Event & { target: HTMLSlotElement }): void {
     const nodes = target.assignedNodes({ flatten: true });
 
-    this.#label ??= this.querySelector('label[slot="label"]') || document.createElement('label');
-    this.#label.htmlFor = this.for ?? '';
-    this.#label.slot = 'label';
-    this.#label.append(...nodes);
-    this.append(this.#label);
+    if (this.#label && nodes.length) {
+      this.#label.innerHTML = '';
+      this.#label.append(...nodes);
+    } else {
+      this.#label ??= this.querySelector('label[slot="label"]') || document.createElement('label');
+      this.#label.htmlFor = this.for ?? '';
+      this.#label.slot = 'label';
+      this.#label.append(...nodes);
+      this.append(this.#label);
+    }
   }
 
   #update(): void {

--- a/packages/core/src/label/label.ts
+++ b/packages/core/src/label/label.ts
@@ -1,6 +1,6 @@
 import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { LitElement, html } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import styles from './label.scss.js';
 
 export class Label extends LitElement {
@@ -12,12 +12,32 @@ export class Label extends LitElement {
   /** The DOM id of the form control this is linked to. */
   @property() for?: string;
 
+  /** The associated form control. */
+  @state() formControl: HTMLElement | null = null;
+
+  /** Whether the associated form control is required. */
+  @state() required?: boolean;
+
   override updated(changes: PropertyValues<this>): void {
     if (changes.has('for')) {
       if (this.for) {
         this.#label?.setAttribute('for', this.for);
+        this.formControl = this.querySelector(`#${this.for}`);
       } else {
         this.#label?.removeAttribute('for');
+        this.formControl = null;
+      }
+    }
+  }
+
+  override willUpdate(changes: PropertyValues<this>): void {
+    super.willUpdate(changes);
+
+    if (changes.has('formControl')) {
+      if (this.formControl) {
+        this.required = this.formControl.hasAttribute('required');
+      } else {
+        this.required = undefined;
       }
     }
   }
@@ -34,6 +54,8 @@ export class Label extends LitElement {
 
     this.#label ??= document.createElement('label');
     this.#label.htmlFor = this.for ?? '';
+    this.#label.slot = 'label';
     this.#label.append(...nodes);
+    this.append(this.#label);
   }
 }

--- a/packages/core/src/label/label.ts
+++ b/packages/core/src/label/label.ts
@@ -1,0 +1,39 @@
+import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
+import { LitElement, html } from 'lit';
+import { property } from 'lit/decorators.js';
+import styles from './label.scss.js';
+
+export class Label extends LitElement {
+  /** @private */
+  static override styles: CSSResultGroup = styles;
+
+  #label?: HTMLLabelElement;
+
+  /** The DOM id of the form control this is linked to. */
+  @property() for?: string;
+
+  override updated(changes: PropertyValues<this>): void {
+    if (changes.has('for')) {
+      if (this.for) {
+        this.#label?.setAttribute('for', this.for);
+      } else {
+        this.#label?.removeAttribute('for');
+      }
+    }
+  }
+
+  override render(): TemplateResult {
+    return html`
+      <slot @slotchange=${this.#onSlotchange} style="display: none"></slot>
+      <slot name="label"></slot>
+    `;
+  }
+
+  #onSlotchange({ target }: Event & { target: HTMLSlotElement }): void {
+    const nodes = target.assignedNodes({ flatten: true });
+
+    this.#label ??= document.createElement('label');
+    this.#label.htmlFor = this.for ?? '';
+    this.#label.append(...nodes);
+  }
+}

--- a/packages/core/src/label/register.ts
+++ b/packages/core/src/label/register.ts
@@ -1,0 +1,9 @@
+import { Label } from './label.js';
+
+customElements.define('sl-label', Label);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sl-label': Label;
+  }
+}


### PR DESCRIPTION
New `<sl-label>` web component for:
- Automatic styling of labels using design tokens
- Automatic adding of required or optional indicators based on UX rules: if the majority of the fields in the form are optional, then show the required fields and the other way around
- Actual `<label>` is still in Light DOM, so fully accessible