### PR TITLE
Add support for localization

### DIFF
--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -1,4 +1,34 @@
 import 'element-internals-polyfill';
+import { configureLocalization } from '@lit/localize';
+
+const { setLocale } = configureLocalization({
+  sourceLocale: 'en',
+  targetLocales: ['nl'],
+  loadLocale: locale => import(`../dist/components/locales/${locale}.js`)
+});
+
+export const decorators = [
+  (story, { globals: { locale = 'en' } }) => {
+    setLocale(locale);
+
+    return story();
+  }
+];
+
+export const globalTypes = {
+  locale: {
+    name: 'Locale',
+    description: 'Internationalization locale',
+    defaultValue: 'en',
+    toolbar: {
+      icon: 'globe',
+      items: [
+        { value: 'en', right: '🇺🇸', title: 'English' },
+        { value: 'nl', right: '🇳🇱', title: 'Nederlands' }
+      ]
+    }
+  }
+};
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -12,3 +42,4 @@ export const parameters = {
     storySort: (a, b) => a.title === b.title ? 0 : a.id.localeCompare(b.id, undefined, { numeric: true })
   }
 };
+

--- a/packages/core/lit-localize.json
+++ b/packages/core/lit-localize.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://raw.githubusercontent.com/lit/lit/main/packages/localize-tools/config.schema.json",
+  "sourceLocale": "en",
+  "targetLocales": ["nl"],
+  "tsConfig": "tsconfig.build.json",
+  "output": {
+    "mode": "runtime",
+    "outputDir": "src/locales",
+    "localeCodesModule": "src/locales/locale-codes.ts"
+  },
+  "interchange": {
+    "format": "xliff",
+    "xliffDir": "src/locales/"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,7 @@
   },
   "scripts": {
     "build": "wireit",
+    "build:locales": "wireit",
     "build:scss": "wireit",
     "build:ts": "wireit",
     "docs": "wireit",
@@ -54,6 +55,16 @@
     "build": {
       "dependencies": [
         "build:ts"
+      ]
+    },
+    "build:locales": {
+      "command": "lit-localize build && eslint --fix \"src/locales/*.ts\"",
+      "files": [
+        "lit-localize.json",
+        "src/locales/*.xlf"
+      ],
+      "output": [
+        "src/locales/*.ts"
       ]
     },
     "build:scss": {
@@ -71,6 +82,7 @@
       "command": "tsc -b ./tsconfig.build.json --pretty",
       "clean": "if-file-deleted",
       "dependencies": [
+        "build:locales",
         "build:scss"
       ],
       "files": [
@@ -121,6 +133,7 @@
     }
   },
   "devDependencies": {
+    "@lit/localize-tools": "^0.6.6",
     "@open-wc/testing": "^3.1.7",
     "@storybook/addon-a11y": "^7.0.0-beta.21",
     "@storybook/addon-docs": "^7.0.0-beta.21",

--- a/packages/core/src/locales/locale-codes.ts
+++ b/packages/core/src/locales/locale-codes.ts
@@ -1,0 +1,18 @@
+// Do not modify this file by hand!
+// Re-generate this file by running lit-localize.
+
+/**
+ * The locale code that templates in this source code are written in.
+ */
+export const sourceLocale = `en`;
+
+/**
+ * The other locale codes that this application is localized into. Sorted
+ * lexicographically.
+ */
+export const targetLocales = [`nl`] as const;
+
+/**
+ * All valid project locale codes. Sorted lexicographically.
+ */
+export const allLocales = [`en`, `nl`] as const;

--- a/packages/core/src/locales/nl.ts
+++ b/packages/core/src/locales/nl.ts
@@ -1,0 +1,13 @@
+// Do not modify this file by hand!
+// Re-generate this file by running lit-localize
+
+import { str } from '@lit/localize';
+
+/* eslint-disable no-irregular-whitespace */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export const templates = {
+  s1e4177e8de76dfc9: `Dit veld volgt niet het gespecificeerde patroon.`,
+  s3ee922cc6e82d53a: `Dit veld moet verplicht ingevuld worden.`,
+  s45d6e41483a83f82: str`Dit veld moet tenminste ${0} karakter${1} lang zijn.`
+};

--- a/packages/core/src/locales/nl.ts
+++ b/packages/core/src/locales/nl.ts
@@ -1,13 +1,7 @@
 // Do not modify this file by hand!
 // Re-generate this file by running lit-localize
 
-import { str } from '@lit/localize';
-
 /* eslint-disable no-irregular-whitespace */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export const templates = {
-  s1e4177e8de76dfc9: `Dit veld volgt niet het gespecificeerde patroon.`,
-  s3ee922cc6e82d53a: `Dit veld moet verplicht ingevuld worden.`,
-  s45d6e41483a83f82: str`Dit veld moet tenminste ${0} karakter${1} lang zijn.`
-};
+export const templates = {};

--- a/packages/core/src/locales/nl.xlf
+++ b/packages/core/src/locales/nl.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<file target-language="nl" source-language="en" original="lit-localize-inputs" datatype="plaintext">
+<body>
+<trans-unit id="s1e4177e8de76dfc9">
+  <source>Please match the specified pattern.</source>
+  <target>Dit veld volgt niet het gespecificeerde patroon.</target>
+</trans-unit>
+<trans-unit id="s45d6e41483a83f82">
+  <source>This field must be at least <x id="0" equiv-text="${count}"/> character<x id="1" equiv-text="${count &gt; 1 ? 's' : ''}"/> long.</source>
+  <target>Dit veld moet tenminste <x id="0" equiv-text="${count}"/> karakter<x id="1" equiv-text="${count &gt; 1 ? 's' : ''}"/> lang zijn.</target>
+</trans-unit>
+<trans-unit id="s3ee922cc6e82d53a">
+  <source>This field must be filled in.</source>
+  <target>Dit veld moet verplicht ingevuld worden.</target>
+</trans-unit>
+</body>
+</file>
+</xliff>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2229,7 +2229,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lit/localize@npm:^0.11.4":
+"@lit/localize-tools@npm:^0.6.6":
+  version: 0.6.6
+  resolution: "@lit/localize-tools@npm:0.6.6"
+  dependencies:
+    "@lit/localize": ^0.11.0
+    "@xmldom/xmldom": ^0.8.2
+    fast-glob: ^3.2.7
+    fs-extra: ^10.0.0
+    jsonschema: ^1.4.0
+    lit: ^2.6.0
+    minimist: ^1.2.5
+    parse5: ^6.0.1
+    source-map-support: ^0.5.19
+    typescript: ~4.7.4
+  bin:
+    lit-localize: bin/lit-localize.js
+  checksum: 40ac896d6fd564d4d24d98f5fd656fe4958eb5debd0d33bb3f960f96bd6ac8695a92604b7906c37869e619a3ecbddb1c4727c90fbaaeb9921893a36e77333f53
+  languageName: node
+  linkType: hard
+
+"@lit/localize@npm:^0.11.0, @lit/localize@npm:^0.11.4":
   version: 0.11.4
   resolution: "@lit/localize@npm:0.11.4"
   dependencies:
@@ -2512,6 +2532,7 @@ __metadata:
   dependencies:
     "@floating-ui/dom": ^1.1.0
     "@lit/localize": ^0.11.4
+    "@lit/localize-tools": ^0.6.6
     "@open-wc/form-control": ^0.4.2
     "@open-wc/scoped-elements": ^2.1.4
     "@open-wc/testing": ^3.1.7
@@ -5139,6 +5160,13 @@ __metadata:
   version: 0.1.0
   resolution: "@webcomponents/template-shadowroot@npm:0.1.0"
   checksum: 82c2f3fa9b156faa31e9b6437e2189e6b30cb9e8050a0849f4b66f3f30adf4af8959210f6042b146418faefa546c09db4f99e16acf1f481f66e615a02405dc57
+  languageName: node
+  linkType: hard
+
+"@xmldom/xmldom@npm:^0.8.2":
+  version: 0.8.6
+  resolution: "@xmldom/xmldom@npm:0.8.6"
+  checksum: b7c5444ec3e4ac8065b00015631b2357bedd7c140962197643dc2cfd444f7251de94cc8aa03a406d6ab9ffc506dd0149f1b7ddebb8a4173965c75846922e4a75
   languageName: node
   linkType: hard
 
@@ -9005,7 +9033,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.1.1, fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.9":
+"fast-glob@npm:^3.1.1, fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9":
   version: 3.2.12
   resolution: "fast-glob@npm:3.2.12"
   dependencies:
@@ -11382,6 +11410,13 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 4f95b5e8a5622b1e9e8f33c96b7ef3158122f595998114d1e7f03985649ea99cb3cd99ce1ed1831ae94c8c8543ab45ebd044207612f31a56fd08462140e46865
+  languageName: node
+  linkType: hard
+
+"jsonschema@npm:^1.4.0":
+  version: 1.4.1
+  resolution: "jsonschema@npm:1.4.1"
+  checksum: c3422d3fc7d33ff7234a806ffa909bb6fb5d1cd664bea229c64a1785dc04cbccd5fc76cf547c6ab6dd7881dbcaf3540a6a9f925a5956c61a9cd3e23a3c1796ef
   languageName: node
   linkType: hard
 
@@ -15933,7 +15968,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:^0.5.16, source-map-support@npm:~0.5.20":
+"source-map-support@npm:^0.5.16, source-map-support@npm:^0.5.19, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:
@@ -17022,6 +17057,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:~4.7.4":
+  version: 4.7.4
+  resolution: "typescript@npm:4.7.4"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 8c1c4007b6ce5b24c49f0e89173ab9e82687cc6ae54418d1140bb63b82d6598d085ac0f993fe3d3d1fbf87a2c76f1f81d394dc76315bc72c7a9f8561c5d8d205
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@^2.9.2 || ^3.0.0 || ^4.0.0#~builtin<compat/typescript>, typescript@patch:typescript@^4.6.2#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.4#~builtin<compat/typescript>":
   version: 4.9.4
   resolution: "typescript@patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ad5954"
@@ -17039,6 +17084,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 8991b4a568bd5a9dab8fa470b5e51368f588e46aebde3a773d9c993ef83e8a1ec0832deae4496d2c788a23c400471117d60b8f9607578ae79779cb3f379308ae
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~4.7.4#~builtin<compat/typescript>":
+  version: 4.7.4
+  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=65a307"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 2eb6e31b04fabec84a4d07b5d567deb5ef0a2971d89d9adb16895f148f7d8508adfb12074abc2efc6966805d3664e68ab67925060e5b0ebd8da616db4b151906
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is another part split from the `feature/input-validation` branch
- Add English and Dutch locales to core
- Add localisation switcher to core storybook