### PR TITLE
Add `HintMixin` for use in form controls

### DIFF
--- a/.changeset/itchy-donkeys-fly.md
+++ b/.changeset/itchy-donkeys-fly.md
@@ -1,0 +1,5 @@
+---
+'@sanomalearning/slds-core': patch
+---
+
+Add hint support to input, radio-group and textarea

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,8 @@
     "./utils": "./dist/components/utils/index.js",
     "./utils/controllers": "./dist/components/utils/controllers/index.js",
     "./utils/data-source": "./dist/components/utils/data-source/index.js",
-    "./utils/decorators": "./dist/components/utils/decorators/index.js"
+    "./utils/decorators": "./dist/components/utils/decorators/index.js",
+    "./utils/form-control": "./dist/components/utils/form-control/index.js"
   },
   "scripts": {
     "build": "wireit",

--- a/packages/core/src/input/input.stories.ts
+++ b/packages/core/src/input/input.stories.ts
@@ -1,5 +1,7 @@
 import type { StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
+import '../button/register.js';
+import '../label/register.js';
 import './register.js';
 
 export default {
@@ -9,7 +11,8 @@ export default {
 export const API: StoryObj = {
   args: {
     disabled: false,
-    placeholder: 'This is placeholder',
+    hint: '',
+    placeholder: 'Type something here',
     prefix: '',
     required: false,
     suffix: '',
@@ -19,10 +22,11 @@ export const API: StoryObj = {
     maxLength: { type: 'number' },
     minLength: { type: 'number' }
   },
-  render: ({ disabled, maxLength, minLength, placeholder, prefix, required, suffix, value }) => html`
+  render: ({ disabled, hint, maxLength, minLength, placeholder, prefix, required, suffix, value }) => html`
     <sl-input
       ?disabled=${disabled}
       ?required=${required}
+      .hint=${hint}
       .maxLength=${maxLength}
       .minLength=${minLength}
       .placeholder=${placeholder}
@@ -31,6 +35,61 @@ export const API: StoryObj = {
       ${prefix ? html`<span slot="prefix">${prefix}</span>` : ''}
       ${suffix ? html`<span slot="suffix">${suffix}</span>` : ''}
     </sl-input>
+  `
+};
+
+export const Disabled: StoryObj = {
+  render: () => html`<sl-input disabled value="I am disabled"></sl-input>`
+};
+
+export const Label: StoryObj = {
+  render: () => html`
+    <style>
+      div {
+        display: flex;
+        flex-direction: column;
+      }
+    </style>
+    <div>
+      <sl-label for="input">What is your name?</sl-label>
+      <sl-input id="input"></sl-input>
+    </div>
+  `
+};
+
+export const Hint: StoryObj = {
+  render: () => html`
+    <style>
+      div {
+        display: flex;
+        flex-direction: column;
+      }
+    </style>
+    <div>
+      <sl-label for="input">Nickname</sl-label>
+      <sl-input id="input" hint="What would you like people to call you?"></sl-input>
+    </div>
+  `
+};
+
+export const RichLabelHint: StoryObj = {
+  render: () => html`
+    <style>
+      div:not([slot]) {
+        display: flex;
+        flex-direction: column;
+      }
+    </style>
+    <div>
+      <sl-label for="input">
+        <label slot="label">Custom <i>label</i></label>
+      </sl-label>
+      <sl-input id="input">
+        <div slot="hint">
+          Hint is an accessible way to provide <strong>additional information</strong> that might help the user
+        </div>
+      </sl-input>
+    </div>
   `
 };
 
@@ -51,10 +110,11 @@ export const Required: StoryObj = {
   render: () => html`<sl-input placeholder="I am required" required></sl-input>`
 };
 
-export const RequiredCustomValidation: StoryObj = {
+export const CustomInput: StoryObj = {
   render: () => html`
-    <sl-input required>
-      <div slot="validation-message">This is a custom validation message for the input.</div>
+    <sl-label for="custom">Custom input</sl-label>
+    <sl-input id="custom">
+      <input id="foo" slot="input" placeholder="I am a custom input" />
     </sl-input>
   `
 };

--- a/packages/core/src/input/input.stories.ts
+++ b/packages/core/src/input/input.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
-import '../button/register.js';
 import '../label/register.js';
 import './register.js';
 

--- a/packages/core/src/input/input.ts
+++ b/packages/core/src/input/input.ts
@@ -3,6 +3,7 @@ import { FormControlMixin } from '@open-wc/form-control';
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { EventsController } from '../utils/controllers/index.js';
+import { HintMixin } from '../utils/form-control/index.js';
 import styles from './input.scss.js';
 
 let nextUniqueId = 0;
@@ -14,7 +15,7 @@ let nextUniqueId = 0;
  * @slot input - The slot for the input element
  * @slot suffix - Content shown after the input
  */
-export class Input extends FormControlMixin(LitElement) {
+export class Input extends FormControlMixin(HintMixin(LitElement)) {
   /** @private */
   static override styles: CSSResultGroup = styles;
 
@@ -143,6 +144,7 @@ export class Input extends FormControlMixin(LitElement) {
         <slot @slotchange=${this.#onSlotchange} name="input"></slot>
         <slot name="suffix"></slot>
       </div>
+      ${this.renderHint()}
     `;
   }
 

--- a/packages/core/src/radio-group/radio-group.scss
+++ b/packages/core/src/radio-group/radio-group.scss
@@ -1,15 +1,23 @@
 :host {
+  --_direction: column;
   --_gap: 0.5rem;
 }
 
 :host {
   align-items: start;
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
-  gap: var(--_gap);
+  gap: 0.25rem;
+  vertical-align: top;
 }
 
 :host([orientation='horizontal']) {
+  --_direction: row;
   --_gap: 1rem;
-  flex-direction: row;
+}
+
+.wrapper {
+  display: flex;
+  flex-direction: var(--_direction);
+  gap: var(--_gap);
 }

--- a/packages/core/src/radio-group/radio-group.stories.ts
+++ b/packages/core/src/radio-group/radio-group.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
-import '../button/register.js';
 import './register.js';
 
 export default {

--- a/packages/core/src/radio-group/radio-group.stories.ts
+++ b/packages/core/src/radio-group/radio-group.stories.ts
@@ -1,5 +1,6 @@
 import type { StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
+import '../button/register.js';
 import './register.js';
 
 export default {
@@ -16,13 +17,13 @@ export const API: StoryObj = {
       control: 'inline-radio',
       options: ['horizontal', 'vertical']
     },
-    selected: {
+    value: {
       control: 'inline-radio',
       options: ['1', '2', '3']
     }
   },
-  render: ({ disabled, selected, orientation }) => html`
-    <sl-radio-group ?disabled=${disabled} .orientation=${orientation} .selected=${selected}>
+  render: ({ disabled, orientation, value }) => html`
+    <sl-radio-group ?disabled=${disabled} .orientation=${orientation} .value=${value}>
       <sl-radio value="1">One</sl-radio>
       <sl-radio value="2">Two</sl-radio>
       <sl-radio value="3">Three</sl-radio>
@@ -43,10 +44,75 @@ export const Disabled: StoryObj = {
 
 export const Selected: StoryObj = {
   render: () => html`
-    <sl-radio-group selected="2">
+    <sl-radio-group value="2">
       <sl-radio value="1">One</sl-radio>
       <sl-radio value="2">Two</sl-radio>
       <sl-radio value="3">Three</sl-radio>
     </sl-radio-group>
+  `
+};
+
+export const Label: StoryObj = {
+  render: () => html`
+    <style>
+      div {
+        display: flex;
+        flex-direction: column;
+      }
+    </style>
+    <div>
+      <sl-label for="radio-group">How many pets do you have?</sl-label>
+      <sl-radio-group id="radio-group">
+        <sl-radio value="0">None</sl-radio>
+        <sl-radio value="1">One</sl-radio>
+        <sl-radio value="2">Two</sl-radio>
+        <sl-radio value="3">Three</sl-radio>
+      </sl-radio-group>
+    </div>
+  `
+};
+
+export const Hint: StoryObj = {
+  render: () => html`
+    <style>
+      div {
+        display: flex;
+        flex-direction: column;
+      }
+    </style>
+    <div>
+      <sl-label for="radio-group">How many pets do you have?</sl-label>
+      <sl-radio-group id="radio-group" hint="Fish count as well.">
+        <sl-radio value="0">None</sl-radio>
+        <sl-radio value="1">One</sl-radio>
+        <sl-radio value="2">Two</sl-radio>
+        <sl-radio value="3">Three</sl-radio>
+      </sl-radio-group>
+    </div>
+  `
+};
+
+export const RichLabelHint: StoryObj = {
+  render: () => html`
+    <style>
+      div:not([slot]) {
+        display: flex;
+        flex-direction: column;
+      }
+    </style>
+    <div>
+      <sl-label for="radio-group">
+        <label slot="label">Custom <i>label</i></label>
+      </sl-label>
+      <sl-radio-group id="radio-group">
+        <sl-radio value="0">None</sl-radio>
+        <sl-radio value="1">One</sl-radio>
+        <sl-radio value="2">Two</sl-radio>
+        <sl-radio value="3">Three</sl-radio>
+        <div slot="hint">
+          Hint is an accessible way to provide <strong>additional information</strong> that might help the user
+        </div>
+      </sl-radio-group>
+    </div>
   `
 };

--- a/packages/core/src/radio-group/radio-group.ts
+++ b/packages/core/src/radio-group/radio-group.ts
@@ -2,7 +2,8 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { FormControlMixin } from '@open-wc/form-control';
 import { LitElement, html } from 'lit';
 import { property, queryAssignedNodes } from 'lit/decorators.js';
-import { RovingTabindexController } from '../utils/controllers/roving-tabindex.js';
+import { EventsController, RovingTabindexController } from '../utils/controllers/index.js';
+import { HintMixin } from '../utils/form-control/index.js';
 import { Radio } from './radio.js';
 import styles from './radio-group.scss.js';
 
@@ -12,53 +13,53 @@ const OBSERVER_OPTIONS: MutationObserverInit = {
   subtree: true
 };
 
-export class RadioGroup extends FormControlMixin(LitElement) {
+export class RadioGroup extends FormControlMixin(HintMixin(LitElement)) {
   /** @private */
   static override styles: CSSResultGroup = styles;
 
-  /** Observe the state of the radios. */
-  #observer?: MutationObserver;
+  /** Events controller. */
+  #events = new EventsController(this);
 
   #rovingTabindexController = new RovingTabindexController<Radio>(this, {
     focusInIndex: (elements: Radio[]) => {
       return elements.findIndex(el => {
-        return this.selected ? !el.disabled && el.value === this.selected : !el.disabled;
+        return this.value ? !el.disabled && el.value === this.value : !el.disabled;
       });
     },
     elementEnterAction: (el: Radio) => {
-      this.selected = el.value;
+      this.value = el.value;
     },
     elements: () => this.buttons,
     isFocusableElement: (el: Radio) => !el.disabled
   });
 
-  get buttons(): Radio[] {
-    return this.defaultNodes?.filter((node): node is Radio => node instanceof Radio) || [];
-  }
+  /** Observe the state of the radios. */
+  #observer?: MutationObserver;
 
   /** The assigned nodes. */
   @queryAssignedNodes() defaultNodes?: Node[];
-
-  /** Whether all the radio's in the group are disabled. */
-  @property({ type: Boolean, reflect: true }) disabled = false;
 
   /** The orientation of the radio's in the group. */
   @property({ type: String, reflect: true }) orientation: 'horizontal' | 'vertical' = 'vertical';
 
   /** The value of the selected radio. */
-  @property() selected = '';
+  @property() value?: string;
+
+  get buttons(): Radio[] {
+    return this.defaultNodes?.filter((node): node is Radio => node instanceof Radio) || [];
+  }
 
   override connectedCallback(): void {
     super.connectedCallback();
 
     this.internals.role = 'radiogroup';
 
+    this.#events.listen(this, 'click', this.#onClick);
+
     this.#observer = new MutationObserver(mutationList => {
       mutationList.forEach(mutation => {
         if (mutation.attributeName === 'checked' && mutation.oldValue === null) {
-          this.selected = (mutation.target as Radio).value;
-
-          this.#updateSelected(this.selected);
+          this.#updateSelected((mutation.target as Radio).value);
         }
       });
     });
@@ -75,20 +76,31 @@ export class RadioGroup extends FormControlMixin(LitElement) {
   override updated(changes: PropertyValues<this>): void {
     super.updated(changes);
 
-    if (changes.has('selected')) {
-      this.#updateSelected(this.selected);
+    if (changes.has('value')) {
+      this.#updateSelected(this.value);
     }
   }
 
   override render(): TemplateResult {
-    return html`<slot @slotchange=${() => this.#rovingTabindexController.clearElementCache()}></slot>`;
+    return html`
+      <div class="wrapper">
+        <slot @slotchange=${() => this.#rovingTabindexController.clearElementCache()}></slot>
+      </div>
+      ${this.renderHint()}
+    `;
   }
 
   override focus(): void {
     this.#rovingTabindexController.focus();
   }
 
-  #updateSelected(value: string): void {
+  #onClick(event: Event): void {
+    event.preventDefault();
+
+    this.focus();
+  }
+
+  #updateSelected(value?: string): void {
     this.#observer?.disconnect();
 
     this.buttons?.forEach(button => {

--- a/packages/core/src/radio-group/radio.ts
+++ b/packages/core/src/radio-group/radio.ts
@@ -1,21 +1,19 @@
-import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import type { IElementInternals } from 'element-internals-polyfill';
+import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
+import { EventsController } from '../utils/controllers/index.js';
 import styles from './radio.scss.js';
 
 export class Radio extends LitElement {
   /** @private */
   static override styles: CSSResultGroup = styles;
 
-  #onClick = (event: Event): void => {
-    event.preventDefault();
-    event.stopPropagation();
+  /** Events controller. */
+  #events = new EventsController(this);
 
-    this.checked = true;
-  };
-
-  protected internals: ElementInternals & IElementInternals;
+  /** Element internals. */
+  readonly internals = this.attachInternals();
 
   /** Whether the radio is selected. */
   @property({ type: Boolean, reflect: true }) checked = false;
@@ -26,28 +24,17 @@ export class Radio extends LitElement {
   /** The value for this radio button. */
   @property() value = '';
 
-  constructor() {
-    super();
-
-    // Fixes typescript error due to missing aria attributes
-    this.internals = this.attachInternals() as ElementInternals & IElementInternals;
-    this.internals.role = 'radio';
-  }
-
   override connectedCallback(): void {
     super.connectedCallback();
 
-    this.addEventListener('click', this.#onClick);
+    this.internals.role = 'radio';
 
+    this.#events.listen(this, 'click', this.#onClick);
+
+    // Move this to a new `FocusableMixin`
     if (!this.hasAttribute('tabindex')) {
       this.tabIndex = 0;
     }
-  }
-
-  override disconnectedCallback(): void {
-    this.removeEventListener('click', this.#onClick);
-
-    super.disconnectedCallback();
   }
 
   override updated(changes: PropertyValues<this>): void {
@@ -57,9 +44,9 @@ export class Radio extends LitElement {
       this.internals.ariaChecked = this.checked ? 'true' : 'false';
 
       if (this.checked) {
-        this.internals.states.add('--checked');
+        (this.internals as IElementInternals).states.add('--checked');
       } else {
-        this.internals.states.delete('--checked');
+        (this.internals as IElementInternals).states.delete('--checked');
       }
     }
   }
@@ -69,5 +56,12 @@ export class Radio extends LitElement {
       <div class="control"></div>
       <slot></slot>
     `;
+  }
+
+  #onClick(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.checked = true;
   }
 }

--- a/packages/core/src/textarea/textarea.ts
+++ b/packages/core/src/textarea/textarea.ts
@@ -3,11 +3,12 @@ import { FormControlMixin } from '@open-wc/form-control';
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { EventsController } from '../utils/controllers/index.js';
+import { HintMixin } from '../utils/form-control/index.js';
 import styles from './textarea.scss.js';
 
 let nextUniqueId = 0;
 
-export class Textarea extends FormControlMixin(LitElement) {
+export class Textarea extends FormControlMixin(HintMixin(LitElement)) {
   /** @private */
   static override styles: CSSResultGroup = styles;
 
@@ -79,6 +80,7 @@ export class Textarea extends FormControlMixin(LitElement) {
       <div @input=${this.#onInput} class="wrapper">
         <slot @slotchange=${this.#onSlotchange} name="textarea"></slot>
       </div>
+      ${this.renderHint()}
     `;
   }
 

--- a/packages/core/src/utils/form-control/hint-mixin.spec.ts
+++ b/packages/core/src/utils/form-control/hint-mixin.spec.ts
@@ -1,0 +1,108 @@
+import type { TemplateResult } from 'lit';
+import { expect, fixture } from '@open-wc/testing';
+import { html, LitElement } from 'lit';
+import { HintMixin } from './hint-mixin.js';
+
+class TestHint extends HintMixin(LitElement) {
+  override firstUpdated(): void {
+    this.append(document.createElement('input'));
+  }
+
+  override render(): TemplateResult {
+    return this.renderHint();
+  }
+}
+
+customElements.define('test-hint', TestHint);
+
+describe('HintMixin', () => {
+  let el: TestHint;
+
+  describe('defaults', () => {
+    beforeEach(async () => {
+      el = await fixture(html`<test-hint></test-hint>`);
+    });
+  
+    it('should have a hint slot', () => {
+      const slot = el.renderRoot.querySelector('slot');
+  
+      expect(slot).to.not.be.null;
+      expect(slot).to.have.attribute('name', 'hint');
+    });
+  
+    it('should render the hint text', async () => {
+      el.hint = 'Hello world';
+      await el.updateComplete;
+  
+      const div = el.querySelector('div');
+      expect(div).to.have.attribute('slot', 'hint');
+      expect(div).to.have.text('Hello world');
+    });
+  
+    it('should link the input to the hint', async () => {
+      el.hint = 'Hello world';
+      await el.updateComplete;
+  
+      const input = el.querySelector('input'),
+        div = el.querySelector('div');
+  
+      expect(div?.id).to.match(/sl-hint-\d+/);
+      expect(input).to.have.attribute('aria-describedby', div?.id);
+
+      el.hint = '';
+      await el.updateComplete;
+  
+      expect(input).not.to.have.attribute('aria-describedby');
+    });
+  });
+
+  describe('slotted hint', () => {
+    beforeEach(async () => {
+      el = await fixture(html`<test-hint><p slot="hint">Hello world!</p></test-hint>`);
+    });
+  
+    it('should link the hint to the input', async () => {
+      const input = el.querySelector('input'),
+        p = el.querySelector('p');
+  
+      expect(p?.id).to.match(/sl-hint-\d+/);
+      expect(input).to.have.attribute('aria-describedby', p?.id);
+    });
+
+    it('should display the hint property over the slotted hint', async () => {
+      el.hint = 'Lorem ipsum';
+      await el.updateComplete;
+
+      const p = el.querySelector('p');
+      expect(p).to.have.attribute('slot', 'hint');
+      expect(p).to.have.text('Lorem ipsum');
+    });
+
+    it('should update the slotted content automatically', async () => {
+      el.querySelector('p')?.remove();
+      
+      const newHint = document.createElement('div');
+      newHint.slot = 'hint';
+      newHint.innerText = 'Foo bar';
+      el.append(newHint);
+      
+      await el.updateComplete;
+      
+      const div = el.querySelector('div');
+      expect(div).to.have.attribute('slot', 'hint');
+      expect(div).to.have.text('Foo bar');
+      expect(div?.id).to.match(/sl-hint-\d+/);
+      
+      const input = el.querySelector('input');
+      expect(input).to.have.attribute('aria-describedby', div?.id);
+    });
+    
+    it('should remove the aria-describedby attribute when the hint is removed', async ()  => {
+      el.querySelector('p')?.remove();
+      await el.updateComplete;
+
+      const input = el.querySelector('input');
+      expect(input).not.to.have.attribute('aria-describedby');
+    });
+  });
+});

--- a/packages/core/src/utils/form-control/hint-mixin.ts
+++ b/packages/core/src/utils/form-control/hint-mixin.ts
@@ -1,0 +1,63 @@
+import type { PropertyValues, ReactiveElement, TemplateResult } from 'lit';
+import type { Constructor } from '../mixin-types.js';
+import { html } from 'lit';
+import { property } from 'lit/decorators.js';
+
+export interface HintInterface {
+  hint?: string;
+  renderHint(): TemplateResult;
+}
+
+let nextUniqueId = 0;
+
+export function HintMixin<T extends Constructor<ReactiveElement>>(constructor: T): T & Constructor<HintInterface> {
+  class Hint extends constructor {
+    /** The hint. If you need to display HTML, use the `hint` slot instead. */
+    @property() hint?: string;
+
+    override updated(changes: PropertyValues<this>): void {
+      super.updated(changes);
+
+      if (changes.has('hint')) {
+        if (this.hint) {
+          this.#updateHint();
+        } else if (changes.get('hint')) {
+          this.#removeHint();
+        }
+      }
+    }
+
+    renderHint(): TemplateResult {
+      return html`<slot @slotchange=${() => this.#updateHint()} name="hint"></slot>`;
+    }
+
+    #updateHint(): void {
+      const input = this.querySelector('input, textarea'),
+        hint = this.querySelector('[slot="hint"]');
+
+      if (hint) {
+        hint.id ||= `sl-hint-${nextUniqueId++}`;
+
+        if (this.hint) {
+          hint.innerHTML = this.hint;
+        }
+
+        input?.setAttribute('aria-describedby', hint.id);
+      } else if (this.hint) {
+        const div = document.createElement('div');
+        div.innerText = this.hint;
+        div.slot = 'hint';
+        this.append(div);
+      } else {
+        input?.removeAttribute('aria-describedby');
+      }
+    }
+
+    #removeHint(): void {
+      this.querySelector('[slot="hint"]')?.remove();
+      this.querySelector('input')?.removeAttribute('aria-describedby');
+    }
+  }
+
+  return Hint;
+}

--- a/packages/core/src/utils/form-control/index.ts
+++ b/packages/core/src/utils/form-control/index.ts
@@ -1,0 +1,1 @@
+export * from './hint-mixin.js';


### PR DESCRIPTION
This part has been split from the `feature/input-validation` branch:
- Adds `HintMixin` from `@sanomalearning/slds-core/utils/form-control`
- Add mixin to input, textarea and radio-group